### PR TITLE
translate label "Dutch" into local language

### DIFF
--- a/src/htdocs/lib/locale.php
+++ b/src/htdocs/lib/locale.php
@@ -2,7 +2,7 @@
 namespace AirQualityInfo\Lib {
     class Locale {
 
-        const SUPPORTED_LANGUAGES = array('cs' => 'Čeština', 'nl' => 'Dutch', 'en' => 'English', 'hu' => 'Magyar', 'pl' => 'Polski', 'ro' => 'Română');
+        const SUPPORTED_LANGUAGES = array('cs' => 'Čeština', 'nl' => 'Nederlands', 'en' => 'English', 'hu' => 'Magyar', 'pl' => 'Polski', 'ro' => 'Română');
 
         const LANG_TO_LOCALE = array('cs' => 'cs_CZ', 'en' => 'en_US', 'hu' => 'hu_HU', 'nl' => 'nl_NL', 'pl' => 'pl_PL', 'ro' => 'ro_RO');
 


### PR DESCRIPTION
Other language labels, f.e. "Polski", are written in their local language, thus the label for NL should be in local language too.